### PR TITLE
Pre processing all profilers during setup

### DIFF
--- a/braincode/benchmarks.py
+++ b/braincode/benchmarks.py
@@ -20,30 +20,31 @@ class ProgramBenchmark:
     def load_all_benchmarks(self, basepath):
         # Populate all benchmarks needs to be setup before calling this method
         metrics = {}
-        fs = os.listdir(os.path.join(basepath, ".cache", "profiler"))
-        for f in fs:
+        inpath = os.path.join(basepath, ".cache", "profiler")
+        for f in os.listdir(inpath):
             if '.benchmark' in f:
-                metrics[f.split('.')[0]] = json.load(f)
+                with open(os.path.join(inpath, f), 'r') as fp:
+                    metrics[f.split('.')[0]] = json.load(fp)
         return metrics
 
     def fit_transform(self, programs):
-        # Pre-requisite -- the programs list and self._fnames list are sorted the same way
-        # Using results stored in cache instead of processing each program again
+        # Pre-requisite -- the programs list and self._fnames list are sorted in the same order
+        # Using results stored in cache instead of processing each program again.
+        # Hence, the input `programs` to this function is unused.
         outputs = []
         for f in self._fnames:
-            print(f)
-            print(list(self._metrics.keys())[:5])
-            qwe
+            f = str(f).split('.')[0] # remove .py
+            f = "_".join(f.split(os.sep)[-2:]) # retain only `en/filename` and rename to `en_filename`
             if self._benchmark == "task-lines":
-                metric = self._metrics[str(f)]['number_of_runtime_steps']
+                metric = self._metrics[f]['number_of_runtime_steps']
             elif self._benchmark == "task-nodes":
-                metric = self._metrics[str(f)]['ast_node_counts']
+                metric = self._metrics[f]['ast_node_counts']
             elif self._benchmark == "task-tokens":
-                metric = self._metrics[str(f)]['token_counts']
+                metric = self._metrics[f]['token_counts']
             elif self._benchmark == "task-halstead":
-                metric = self._metrics[str(f)]['program_length']
+                metric = self._metrics[f]['program_length']
             elif self._benchmark == "task-cyclomatic":
-                metric = self._metrics[str(f)]['cyclomatic_complexity']
+                metric = self._metrics[f]['cyclomatic_complexity']
             else:
                 raise ValueError(
                     "Undefined program metric. Make sure to use valid identifier."

--- a/braincode/benchmarks.py
+++ b/braincode/benchmarks.py
@@ -7,6 +7,7 @@ from io import BytesIO
 from tokenize import tok_name, tokenize
 
 import numpy as np
+import sys
 
 
 class ProgramBenchmark:
@@ -14,46 +15,46 @@ class ProgramBenchmark:
         self._benchmark = benchmark
         self._base_path = basepath
         self._fnames = fnames
+        self._metrics = self.load_all_benchmarks(self.basepath)
+      
+    def load_all_benchmarks(self, basepath):
+        # Populate all benchmarks needs to be setup before calling this method
+        metrics = {}
+        fs = os.listdir(os.path.join(basepath, ".cache", "profiler"))
+        for f in fs:
+            if '.benchmark' in f:
+                metrics[f.split('.')[0]] = json.load(f)
+        return metrics
 
     def fit_transform(self, programs):
         outputs = []
         for i, program in enumerate(programs):
             metrics = ProgramMetrics(program, str(self._fnames[i]), self._base_path)
             if self._benchmark == "task-lines":
-                metric = metrics.get_number_of_runtime_steps()
+                metric = metrics._metrics[str(self._fnames[i])]['number_of_runtime_steps']
             elif self._benchmark == "task-nodes":
-                metric = metrics.get_ast_node_counts()
+                metric = metrics._metrics[str(self._fnames[i])]['ast_node_counts']
             elif self._benchmark == "task-tokens":
-                metric = metrics.get_token_counts()
+                metric = metrics._metrics[str(self._fnames[i])]['token_counts']
+            elif self._benchmark == "task-halstead":
+                metric = metrics._metrics[str(self._fnames[i])]['program_length']
+            elif self._benchmark == "task-cyclomatic":
+                metric = metrics._metrics[str(self._fnames[i])]['cyclomatic_complexity']
             else:
-                complexity = metrics.get_halstead_complexity_metrics()
-                if self._benchmark == "task-halstead":
-                    metric = complexity["program_length"]
-                elif self._benchmark == "task-cyclomatic":
-                    metric = complexity["cyclomatic_complexity"]
-                else:
-                    raise ValueError(
-                        "Undefined program metric. Make sure to use valid identifier."
-                    )
+                raise ValueError(
+                    "Undefined program metric. Make sure to use valid identifier."
+                )
             outputs.append(metric)
         return np.array(outputs).reshape([-1, 1])
 
 
 class ProgramMetrics:
     def __init__(self, program, path, base_path):
-        self.program = program
-        self.path = path
+        self.program = program        
+        self.fname = "_".join(path.split(os.sep)[-2:])
         self.base_path = base_path
         self.outpath = os.path.join(self.base_path, ".cache", "profiler")
-        os.makedirs(self.outpath, exist_ok=True)
-        self.fname = "_".join(self.path.split(os.sep)[-2:])
-
-        # Prepare a copy of the src for the profilers
-        if not os.path.exists(os.path.join(self.outpath, self.fname)):
-            src = self._prepare_src_for_profiler(program)
-            with open(os.path.join(self.outpath, self.fname), "w") as fp:
-                fp.write(src)
-
+  
     def get_token_counts(self):
         exclude_tokens_types = [
             "NEWLINE",
@@ -124,14 +125,6 @@ class ProgramMetrics:
         # print(json.dumps(metrics, indent=2))
         return metrics
 
-    @staticmethod
-    def _prepare_src_for_profiler(src):
-        indent = "  "
-        src = src.replace("\n", "\n" + indent)
-        src = indent + src
-        src = "@profile\ndef profile_me():\n" + src + "\nprofile_me()"
-        return src
-
     def get_number_of_runtime_steps(self, sec=30):
         """
         Requires the package line_profiler to be installed.
@@ -141,7 +134,7 @@ class ProgramMetrics:
         :param sec: Timeout for subprocess.run
         :return:[# of lines] executed
         """
-        if not self.path[-3:] == ".py":
+        if not self.fname[-3:] == ".py":
             raise ValueError("Unrecognized file type")
         
         if not os.path.exists(os.path.join(self.outpath, self.fname + ".lprof")):
@@ -167,7 +160,7 @@ class ProgramMetrics:
         with open(os.path.join(self.outpath, self.fname + ".lprof"), "rb") as fp:
             obj = pkl.load(fp)
             if len(obj.timings) > 1:
-                print("something not right")
+                raise ValueError("The number of timings cannot be greater than 1 in lprof dump")
             else:
                 # obj.timings format - {filename: [(x1, y1, z1), (x2, y2, z2), (x3, y3, z3)]}
                 # x1 - line number, y1 - hits, z1 - time spent on the line

--- a/braincode/benchmarks.py
+++ b/braincode/benchmarks.py
@@ -15,7 +15,7 @@ class ProgramBenchmark:
         self._benchmark = benchmark
         self._base_path = basepath
         self._fnames = fnames
-        self._metrics = self.load_all_benchmarks(self.basepath)
+        self._metrics = self.load_all_benchmarks(self._base_path)
       
     def load_all_benchmarks(self, basepath):
         # Populate all benchmarks needs to be setup before calling this method
@@ -27,19 +27,23 @@ class ProgramBenchmark:
         return metrics
 
     def fit_transform(self, programs):
+        # Pre-requisite -- the programs list and self._fnames list are sorted the same way
+        # Using results stored in cache instead of processing each program again
         outputs = []
-        for i, program in enumerate(programs):
-            metrics = ProgramMetrics(program, str(self._fnames[i]), self._base_path)
+        for f in self._fnames:
+            print(f)
+            print(list(self._metrics.keys())[:5])
+            qwe
             if self._benchmark == "task-lines":
-                metric = metrics._metrics[str(self._fnames[i])]['number_of_runtime_steps']
+                metric = self._metrics[str(f)]['number_of_runtime_steps']
             elif self._benchmark == "task-nodes":
-                metric = metrics._metrics[str(self._fnames[i])]['ast_node_counts']
+                metric = self._metrics[str(f)]['ast_node_counts']
             elif self._benchmark == "task-tokens":
-                metric = metrics._metrics[str(self._fnames[i])]['token_counts']
+                metric = self._metrics[str(f)]['token_counts']
             elif self._benchmark == "task-halstead":
-                metric = metrics._metrics[str(self._fnames[i])]['program_length']
+                metric = self._metrics[str(f)]['program_length']
             elif self._benchmark == "task-cyclomatic":
-                metric = metrics._metrics[str(self._fnames[i])]['cyclomatic_complexity']
+                metric = self._metrics[str(f)]['cyclomatic_complexity']
             else:
                 raise ValueError(
                     "Undefined program metric. Make sure to use valid identifier."

--- a/braincode/decoding.py
+++ b/braincode/decoding.py
@@ -87,7 +87,7 @@ class Analysis(ABC):
     def _plot(self):
         Plotter(self).plot()
 
-    def run(self, perms=True, iters=2):
+    def run(self, perms=True, iters=1000):
         self._run_pipeline("score")
         if perms:
             self._run_pipeline("null", iters)

--- a/braincode/decoding.py
+++ b/braincode/decoding.py
@@ -87,7 +87,7 @@ class Analysis(ABC):
     def _plot(self):
         Plotter(self).plot()
 
-    def run(self, perms=True, iters=1000):
+    def run(self, perms=True, iters=2):
         self._run_pipeline("score")
         if perms:
             self._run_pipeline("null", iters)

--- a/braincode/utils.py
+++ b/braincode/utils.py
@@ -2,6 +2,7 @@ import json
 import os
 import pickle as pkl
 import sys
+import tqdm
 
 import numpy as np
 from braincode.benchmarks import ProgramMetrics
@@ -18,15 +19,16 @@ def populate_benchmarks(basepath):
         return src
 
     basepath = sys.argv[1]
-    inpath = os.path.join(basepath, "inputs", "")
+    inpath = os.path.join(basepath, "inputs", "python_programs")
     outpath = os.path.join(basepath, ".cache", "profiler")
     os.makedirs(outpath, exist_ok=True)
     
     # For every program in the dataset
     cnt = 0
     for ff in os.listdir(inpath):
+        print(ff)
         if ff in ['en', 'jap']:
-            for f in os.listdir(os.path.join(inpath, ff)):
+            for f in tqdm.tqdm(os.listdir(os.path.join(inpath, ff))):
                 if '.py' not in f:
                     continue
 
@@ -47,9 +49,9 @@ def populate_benchmarks(basepath):
                 all_metrics['ast_node_counts'] = metrics.get_ast_node_counts()
                 all_metrics['token_counts'] = metrics.get_token_counts()
                 all_metrics['program_length'] = metrics.get_halstead_complexity_metrics()['program_length']
-                all_metrics['cyclomatic_complexity'] = metrics.get_halstead_complexity_metrics()['complexity']
+                all_metrics['cyclomatic_complexity'] = metrics.get_halstead_complexity_metrics()['cyclomatic_complexity']
 
-                with open(outpath, fname+".benchmark") as fp:
+                with open(os.path.join(outpath, fname+".benchmark"), 'w') as fp:
                     json.dump(all_metrics, fp)
                 
                 cnt += 1

--- a/setup/_setup_inputs.sh
+++ b/setup/_setup_inputs.sh
@@ -10,3 +10,6 @@ cd $HOME_DIR
 
 wget -O inputs.zip https://www.dropbox.com/s/78e0r8kmmnwfa1m/inputs.zip?dl=0
 unzip inputs.zip -d inputs
+
+# Process and populate benchmark metrics on input files
+python -m braincode.utils $1 2


### PR DESCRIPTION
The profilers are now run once during setup. 
All benchmark tasks will now read the profiler outputs from a file instead of executing it in each run of a benchmark task.